### PR TITLE
Upgrade to JDK 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,11 +61,11 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
       - name: 'Build with Gradle (if Gradle)'
         uses: gradle/gradle-build-action@982da8e78c05368c70dac0351bb82647a9e9a5d2 # v2.11.1
         if: ${{ matrix.tool == 'gradle' }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Abort-Mission](.github/assets/Abort-Mission-logo_export_transparent_640.png)
 
 [![GitHub license](https://img.shields.io/github/license/nagyesta/abort-mission-examples?color=informational)](https://raw.githubusercontent.com/nagyesta/abort-mission-examples/main/LICENSE)
-[![Java version](https://img.shields.io/badge/Java%20version-11-yellow?logo=java)](https://img.shields.io/badge/Java%20version-11-yellow?logo=java)
+[![Java version](https://img.shields.io/badge/Java%20version-17-yellow?logo=java)](https://img.shields.io/badge/Java%20version-17-yellow?logo=java)
 [![JavaCI](https://img.shields.io/github/actions/workflow/status/nagyesta/abort-mission-examples/build.yml?logo=github&branch=main)](https://github.com/nagyesta/abort-mission-examples/actions/workflows/build.yml)
 
 [![last_commit](https://img.shields.io/github/last-commit/nagyesta/abort-mission-examples?logo=git)](https://img.shields.io/github/last-commit/nagyesta/abort-mission-examples?logo=git)

--- a/gradle/cucumber/README.md
+++ b/gradle/cucumber/README.md
@@ -1,7 +1,7 @@
 ![Abort-Mission](../../.github/assets/Abort-Mission-logo_export_transparent_640.png)
 
 [![GitHub license](https://img.shields.io/github/license/nagyesta/abort-mission-examples?color=informational)](https://raw.githubusercontent.com/nagyesta/abort-mission-examples/main/LICENSE)
-[![Java version](https://img.shields.io/badge/Java%20version-11-yellow?logo=java)](https://img.shields.io/badge/Java%20version-11-yellow?logo=java)
+[![Java version](https://img.shields.io/badge/Java%20version-17-yellow?logo=java)](https://img.shields.io/badge/Java%20version-17-yellow?logo=java)
 [![JavaCI](https://img.shields.io/github/actions/workflow/status/nagyesta/abort-mission-examples/build.yml?logo=github&branch=main)](https://github.com/nagyesta/abort-mission-examples/actions/workflows/build.yml)
 
 [![last_commit](https://img.shields.io/github/last-commit/nagyesta/abort-mission-examples?logo=git)](https://img.shields.io/github/last-commit/nagyesta/abort-mission-examples?logo=git)

--- a/gradle/cucumber/build.gradle.kts
+++ b/gradle/cucumber/build.gradle.kts
@@ -1,12 +1,12 @@
 plugins {
     id("java")
-    id("com.github.nagyesta.abort-mission-gradle-plugin") version "4.1.46"
+    id("com.github.nagyesta.abort-mission-gradle-plugin") version "5.0.0"
 }
 
 group = "com.github.nagyesta.abort-mission.examples"
 version = "1.0-SNAPSHOT"
 
-java.sourceCompatibility = org.gradle.api.JavaVersion.VERSION_11
+java.sourceCompatibility = org.gradle.api.JavaVersion.VERSION_17
 
 repositories {
     mavenCentral()
@@ -25,18 +25,18 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
     testImplementation("org.junit.vintage:junit-vintage-engine:5.10.1")
     // HINT: Add Booster to integrate Abort-Mission
-    testImplementation("com.github.nagyesta.abort-mission.boosters:abort.booster-cucumber-jvm:4.2.122")
+    testImplementation("com.github.nagyesta.abort-mission.boosters:abort.booster-cucumber-jvm:5.0.0")
 }
 
 // HINT: Configure Abort-Mission plugin
 abortMission {
-    version = "4.2.0"
+    version = "5.0.0"
     relaxedValidation = true
 }
 
 tasks.test {
     // Define output file
-    outputs.file(file("$buildDir/reports/abort-mission/abort-mission-report.json"))
+    outputs.file(layout.buildDirectory.file("reports/abort-mission/abort-mission-report.json").get().asFile)
     useJUnitPlatform()
     // Pass the API key if you have one provided
     systemProperty("API_KEY", project.ext.properties.computeIfAbsent("apiKey") { "-" })

--- a/gradle/junit4/README.md
+++ b/gradle/junit4/README.md
@@ -1,7 +1,7 @@
 ![Abort-Mission](../../.github/assets/Abort-Mission-logo_export_transparent_640.png)
 
 [![GitHub license](https://img.shields.io/github/license/nagyesta/abort-mission-examples?color=informational)](https://raw.githubusercontent.com/nagyesta/abort-mission-examples/main/LICENSE)
-[![Java version](https://img.shields.io/badge/Java%20version-11-yellow?logo=java)](https://img.shields.io/badge/Java%20version-11-yellow?logo=java)
+[![Java version](https://img.shields.io/badge/Java%20version-17-yellow?logo=java)](https://img.shields.io/badge/Java%20version-17-yellow?logo=java)
 [![JavaCI](https://img.shields.io/github/actions/workflow/status/nagyesta/abort-mission-examples/build.yml?logo=github&branch=main)](https://github.com/nagyesta/abort-mission-examples/actions/workflows/build.yml)
 
 [![last_commit](https://img.shields.io/github/last-commit/nagyesta/abort-mission-examples?logo=git)](https://img.shields.io/github/last-commit/nagyesta/abort-mission-examples?logo=git)

--- a/gradle/junit4/build.gradle.kts
+++ b/gradle/junit4/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 group = "com.github.nagyesta.abort-mission.examples"
 version = "1.0-SNAPSHOT"
 
-java.sourceCompatibility = org.gradle.api.JavaVersion.VERSION_11
+java.sourceCompatibility = org.gradle.api.JavaVersion.VERSION_17
 
 repositories {
     mavenCentral()
@@ -22,7 +22,7 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:2.16.1")
     testImplementation("junit:junit:4.13.2")
     // HINT: Add Booster to integrate Abort-Mission
-    testImplementation("com.github.nagyesta.abort-mission.boosters:abort.booster-junit4-experimental:4.2.122")
+    testImplementation("com.github.nagyesta.abort-mission.boosters:abort.booster-junit4-experimental:5.0.0")
 }
 
 tasks.test {

--- a/gradle/jupiter/README.md
+++ b/gradle/jupiter/README.md
@@ -1,7 +1,7 @@
 ![Abort-Mission](../../.github/assets/Abort-Mission-logo_export_transparent_640.png)
 
 [![GitHub license](https://img.shields.io/github/license/nagyesta/abort-mission-examples?color=informational)](https://raw.githubusercontent.com/nagyesta/abort-mission-examples/main/LICENSE)
-[![Java version](https://img.shields.io/badge/Java%20version-11-yellow?logo=java)](https://img.shields.io/badge/Java%20version-11-yellow?logo=java)
+[![Java version](https://img.shields.io/badge/Java%20version-17-yellow?logo=java)](https://img.shields.io/badge/Java%20version-17-yellow?logo=java)
 [![JavaCI](https://img.shields.io/github/actions/workflow/status/nagyesta/abort-mission-examples/build.yml?logo=github&branch=main)](https://github.com/nagyesta/abort-mission-examples/actions/workflows/build.yml)
 
 [![last_commit](https://img.shields.io/github/last-commit/nagyesta/abort-mission-examples?logo=git)](https://img.shields.io/github/last-commit/nagyesta/abort-mission-examples?logo=git)

--- a/gradle/jupiter/build.gradle.kts
+++ b/gradle/jupiter/build.gradle.kts
@@ -1,12 +1,12 @@
 plugins {
     id("java")
-    id("com.github.nagyesta.abort-mission-gradle-plugin") version "4.1.46"
+    id("com.github.nagyesta.abort-mission-gradle-plugin") version "5.0.0"
 }
 
 group = "com.github.nagyesta.abort-mission.examples"
 version = "1.0-SNAPSHOT"
 
-java.sourceCompatibility = org.gradle.api.JavaVersion.VERSION_11
+java.sourceCompatibility = org.gradle.api.JavaVersion.VERSION_17
 
 repositories {
     mavenCentral()
@@ -23,17 +23,17 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:2.16.1")
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
     // HINT: Add Booster to integrate Abort-Mission
-    testImplementation("com.github.nagyesta.abort-mission.boosters:abort.booster-junit-jupiter:4.2.122")
+    testImplementation("com.github.nagyesta.abort-mission.boosters:abort.booster-junit-jupiter:5.0.0")
 }
 
 // HINT: Configure Abort-Mission plugin
 abortMission {
-    version = "4.2.0"
+    version = "5.0.0"
 }
 
 tasks.test {
     // Define output file
-    outputs.file(file("$buildDir/reports/abort-mission/abort-mission-report.json"))
+    outputs.file(layout.buildDirectory.file("reports/abort-mission/abort-mission-report.json").get().asFile)
     useJUnitPlatform()
     // Pass the API key if you have one provided
     systemProperty("API_KEY", project.ext.properties.computeIfAbsent("apiKey") { "-" })

--- a/gradle/testng/README.md
+++ b/gradle/testng/README.md
@@ -1,7 +1,7 @@
 ![Abort-Mission](../../.github/assets/Abort-Mission-logo_export_transparent_640.png)
 
 [![GitHub license](https://img.shields.io/github/license/nagyesta/abort-mission-examples?color=informational)](https://raw.githubusercontent.com/nagyesta/abort-mission-examples/main/LICENSE)
-[![Java version](https://img.shields.io/badge/Java%20version-11-yellow?logo=java)](https://img.shields.io/badge/Java%20version-11-yellow?logo=java)
+[![Java version](https://img.shields.io/badge/Java%20version-17-yellow?logo=java)](https://img.shields.io/badge/Java%20version-17-yellow?logo=java)
 [![JavaCI](https://img.shields.io/github/actions/workflow/status/nagyesta/abort-mission-examples/build.yml?logo=github&branch=main)](https://github.com/nagyesta/abort-mission-examples/actions/workflows/build.yml)
 
 [![last_commit](https://img.shields.io/github/last-commit/nagyesta/abort-mission-examples?logo=git)](https://img.shields.io/github/last-commit/nagyesta/abort-mission-examples?logo=git)

--- a/gradle/testng/build.gradle.kts
+++ b/gradle/testng/build.gradle.kts
@@ -1,12 +1,12 @@
 plugins {
     id("java")
-    id("com.github.nagyesta.abort-mission-gradle-plugin") version "4.1.46"
+    id("com.github.nagyesta.abort-mission-gradle-plugin") version "5.0.0"
 }
 
 group = "com.github.nagyesta.abort-mission.examples"
 version = "1.0-SNAPSHOT"
 
-java.sourceCompatibility = org.gradle.api.JavaVersion.VERSION_11
+java.sourceCompatibility = org.gradle.api.JavaVersion.VERSION_17
 
 repositories {
     mavenCentral()
@@ -23,7 +23,7 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:2.16.1")
     testImplementation("org.testng:testng:7.9.0")
     // HINT: Add Booster to integrate Abort-Mission
-    testImplementation("com.github.nagyesta.abort-mission.boosters:abort.booster-testng:4.2.122")
+    testImplementation("com.github.nagyesta.abort-mission.boosters:abort.booster-testng:5.0.0")
 }
 
 // HINT: Configure Abort-Mission plugin
@@ -33,7 +33,7 @@ abortMission {
 
 tasks.test {
     // Define output file
-    outputs.file(file("$buildDir/reports/abort-mission/abort-mission-report.json"))
+    outputs.file(layout.buildDirectory.file("reports/abort-mission/abort-mission-report.json").get().asFile)
     useTestNG()
     // Pass the API key if you have one provided
     systemProperty("API_KEY", project.ext.properties.computeIfAbsent("apiKey") { "-" })

--- a/maven/mvn-jupiter/README.md
+++ b/maven/mvn-jupiter/README.md
@@ -1,7 +1,7 @@
 ![Abort-Mission](../../.github/assets/Abort-Mission-logo_export_transparent_640.png)
 
 [![GitHub license](https://img.shields.io/github/license/nagyesta/abort-mission-examples?color=informational)](https://raw.githubusercontent.com/nagyesta/abort-mission-examples/main/LICENSE)
-[![Java version](https://img.shields.io/badge/Java%20version-11-yellow?logo=java)](https://img.shields.io/badge/Java%20version-11-yellow?logo=java)
+[![Java version](https://img.shields.io/badge/Java%20version-17-yellow?logo=java)](https://img.shields.io/badge/Java%20version-17-yellow?logo=java)
 [![JavaCI](https://img.shields.io/github/actions/workflow/status/nagyesta/abort-mission-examples/build.yml?logo=github&branch=main)](https://github.com/nagyesta/abort-mission-examples/actions/workflows/build.yml)
 
 [![last_commit](https://img.shields.io/github/last-commit/nagyesta/abort-mission-examples?logo=git)](https://img.shields.io/github/last-commit/nagyesta/abort-mission-examples?logo=git)

--- a/maven/mvn-jupiter/pom.xml
+++ b/maven/mvn-jupiter/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>com.github.nagyesta.abort-mission.boosters</groupId>
             <artifactId>abort.booster-junit-jupiter</artifactId>
-            <version>4.2.122</version>
+            <version>5.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -75,7 +75,7 @@
             <plugin>
                 <groupId>com.github.nagyesta.abort-mission</groupId>
                 <artifactId>abort-mission-maven-plugin</artifactId>
-                <version>2.1.6</version>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>generate-report</id>


### PR DESCRIPTION
__Issue:__ https://github.com/nagyesta/abort-mission/issues/377

### Description
<!-- A short summary of changes -->

- Upgrades JDK versions to 17 in all workflows
- Prepares Abort Mission version updates (to use the JDK 17 Abort Mission version)
- Stops using the deprecated buildDir Gradle reference

### Entry point
<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The changes are focusing on the issue at hand

### Notes

-
<!-- Any additional remarks you may have. -->
